### PR TITLE
fast api highlighted issues this seems to fix it

### DIFF
--- a/ukrdc_sqla/errorsdb.py
+++ b/ukrdc_sqla/errorsdb.py
@@ -3,8 +3,7 @@
 from typing import Any, List
 
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, MetaData, String
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import Mapped, relationship
+from sqlalchemy.orm import Mapped, relationship, declarative_base
 
 metadata = MetaData()
 Base: Any = declarative_base(metadata=metadata)

--- a/ukrdc_sqla/errorsdb.py
+++ b/ukrdc_sqla/errorsdb.py
@@ -6,7 +6,7 @@ from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, MetaData,
 from sqlalchemy.orm import Mapped, relationship, declarative_base
 
 metadata = MetaData()
-Base: Any = declarative_base(metadata=metadata)
+Base = declarative_base(metadata=metadata)
 
 
 class Channel(Base):


### PR DESCRIPTION
with updating the fast api UI-265 alot of warnings can be seen with methods that use a column attribute( it does not see that it is a column but rather just the return type) changing the import seems to fix this, i assume that the prior is left for compatibility and is not actually updated or another issue