### PR TITLE
feat(UK-29): RADAR Extract - Restrict RADAR Exports

### DIFF
--- a/ukrdc_sqla/ukrdc.py
+++ b/ukrdc_sqla/ukrdc.py
@@ -63,6 +63,14 @@ class SendingExtractMetadata(Base):
         "metadata", JSON, nullable=True
     )
     comment: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    enable_radar_export: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=True,
+        sqla_info=ColumnInfo(
+            label="enable radar exports",
+            description="A flag to enable weather the radar exporter will export for this sending extract",
+        ),
+    )
 
 
 class PatientRecord(Base):


### PR DESCRIPTION
added a bool field to the sendingextractmetadata table this makes more sense then adding to facility tables and cluttering that